### PR TITLE
Fix relative import

### DIFF
--- a/grapetree.py
+++ b/grapetree.py
@@ -24,16 +24,16 @@ The stand-alone version emulates the EnteroBase version through a lightweight
 webserver running on your local computer.  You will be interacting with the
 program as you would in EnteroBase; through a web browser.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
-from module import app
+from .module import app
 import threading
 import webbrowser
 import traceback
 import time
 import argparse
 import os, sys, shutil
-from module.MSTrees import backend, add_args
+from .module.MSTrees import backend, add_args
 import psutil
 import multiprocessing
 


### PR DESCRIPTION
Fix python 2/3 compatibility issue with relative import, according [PEP328](https://www.python.org/dev/peps/pep-0328/).
Should answer issues #84 and #80.